### PR TITLE
Update Ruby coding style guide

### DIFF
--- a/09-ruby.md
+++ b/09-ruby.md
@@ -3,8 +3,8 @@
 Exactly as per [GitHub's Ruby style guide][github-ruby], with the following
 exceptions:
 
-* Four spaces, not two, for indentation
-
 * No requirement to use TomDoc for documentation
+
+* Javascript object syntax for hashes is allowed. For example: { key1: :value1, key2: "value 2", key3: 3 }
 
 [github-ruby]: https://github.com/styleguide/ruby


### PR DESCRIPTION
Reverting to universal standard of 2 spaces per soft tab indent.

Adding ability to use modern and terse JSON notation for Ruby hashes.